### PR TITLE
Disable systemd part of installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 mysqld_exporter_binary_local_dir: ""
+mysqld_exporter_binary_remote_dir: "/usr/local/bin/mysqld_exporter"
+
 mysqld_exporter_version: 0.12.1
 mysqld_exporter_web_listen_address: "0.0.0.0:9104"
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,19 +1,19 @@
 ---
-- name: Create the MySQL Exporter group
-  group:
-    name: "{{ __mysqld_exporter_group }}"
-    state: present
-    system: true
+#- name: Create the MySQL Exporter group
+#  group:
+#    name: "{{ __mysqld_exporter_group }}"
+#    state: present
+#    system: true
 
-- name: Create the MySQL Exporter user
-  user:
-    name: "{{ __mysqld_exporter_user }}"
-    groups: "{{ __mysqld_exporter_group }}"
-    append: true
-    shell: /usr/sbin/nologin
-    system: true
-    createhome: false
-    home: /
+#- name: Create the MySQL Exporter user
+#  user:
+#    name: "{{ __mysqld_exporter_user }}"
+#    groups: "{{ __mysqld_exporter_group }}"
+#    append: true
+#    shell: /usr/sbin/nologin
+#    system: true
+#    createhome: false
+#    home: /
 
 - block:
     - name: Download mysqld_exporter binary to local folder
@@ -41,32 +41,32 @@
     - name: Propagate mysqld_exporter binaries
       copy:
         src: "/tmp/mysqld_exporter-{{ mysqld_exporter_version }}.linux-{{ go_arch_map[ansible_architecture] | default(ansible_architecture) }}/mysqld_exporter"
-        dest: "/usr/local/bin/mysqld_exporter"
+        dest: "{{ mysqld_exporter_binary_remote_dir }}"
         mode: 0755
         owner: root
         group: root
-      notify:
-        - restart mysqld exporter
+#      notify:
+#        - restart mysqld exporter
       when: not ansible_check_mode
   when: mysqld_exporter_binary_local_dir | length == 0
 
 - name: propagate locally distributed mysqld_exporter binary
   copy:
     src: "{{ mysqld_exporter_binary_local_dir }}/mysqld_exporter"
-    dest: "/usr/local/bin/mysqld_exporter"
+    dest: "{{ mysqld_exporter_binary_remote_dir }}"
     mode: 0755
     owner: root
     group: root
   when: mysqld_exporter_binary_local_dir | length > 0
-  notify: restart mysqld exporter
+#  notify: restart mysqld exporter
 
-- name: Copy the mysqld_exporter systemd service file
-  template:
-    src: mysqld_exporter.service.j2
-    dest: /etc/systemd/system/mysqld_exporter.service
-    owner: root
-    group: root
-    mode: 0644
-  no_log: "{{ not lookup('env', 'ANSIBLE_DEBUG') | bool }}"
-  notify:
-    - restart mysqld exporter
+#- name: Copy the mysqld_exporter systemd service file
+#  template:
+#    src: mysqld_exporter.service.j2
+#    dest: /etc/systemd/system/mysqld_exporter.service
+#    owner: root
+#    group: root
+#    mode: 0644
+#  no_log: "{{ not lookup('env', 'ANSIBLE_DEBUG') | bool }}"
+#  notify:
+#    - restart mysqld exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,9 +3,9 @@
 
 - import_tasks: install.yml
 
-- name: Ensure mysqld_exporter is enabled on boot
-  systemd:
-    daemon_reload: true
-    started: restarted
-    name: mysqld_exporter
-    enabled: true
+#- name: Ensure mysqld_exporter is enabled on boot
+#  systemd:
+#    daemon_reload: true
+#    started: restarted
+#    name: mysqld_exporter
+#    enabled: true

--- a/tasks/preflight.yml
+++ b/tasks/preflight.yml
@@ -1,20 +1,20 @@
 ---
-- name: Assert usage of systemd as an init system
-  assert:
-    that: ansible_service_mgr == 'systemd'
-    msg: "This role only works with systemd"
+#- name: Assert usage of systemd as an init system
+#  assert:
+#    that: ansible_service_mgr == 'systemd'
+#    msg: "This role only works with systemd"
 
-- name: Get systemd version
-  command: systemctl --version
-  changed_when: false
-  check_mode: false
-  register: __systemd_version
-  tags:
-    - skip_ansible_lint
+#- name: Get systemd version
+#  command: systemctl --version
+#  changed_when: false
+#  check_mode: false
+#  register: __systemd_version
+#  tags:
+#    - skip_ansible_lint
 
-- name: Set systemd version fact
-  set_fact:
-    mysqld_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0] | regex_replace('^systemd\\s(\\d+).*$', '\\1') }}"
+#- name: Set systemd version fact
+#  set_fact:
+#    mysqld_exporter_systemd_version: "{{ __systemd_version.stdout_lines[0] | regex_replace('^systemd\\s(\\d+).*$', '\\1') }}"
 
 - name: Naive assertion of proper listen address
   assert:


### PR DESCRIPTION
We don't have systemd on our server so had to fork the original repo and comment out systemd related parts.

- Commented out systemd related parts
- Replaced hardcoded destination path where archive with software us unpacked with a variable